### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python main.py"

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Put the token into the env file.
 Rename it from `env.example` to `.env`.
 Make uptime robot ping it.
 Ok, not good explanation but ok.
+
+[![Run on Repl.it](https://repl.it/badge/github/RealCyGuy/repl-it-discord-bot)](https://repl.it/github/RealCyGuy/repl-it-discord-bot)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@RealCyGuy/repl-it-discord-bot).